### PR TITLE
Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Using avrdude with the Raspberry Pi
 ===================================
 
 Since the Raspberry Pi lacks a DTR pin that makes it oh-so-easy to upload your hex files into
-the avr, we need this hack to make it just as easy.  When you wire up your atmega chip, be sure
-to connect one of the digital gpio pins to the reset pin, and then you'll be able to use avrdude
-as if your serial cable actually had a dtr pin.
+the AVR, we need this hack to make it just as easy.  When you wire up your ATmega chip, be sure
+to connect one of the digital GPIO pins to the reset pin, and then you'll be able to use avrdude
+as if your serial cable actually had a DTR pin.
 
 Instructions:
 -------------
@@ -25,23 +25,21 @@ and symlink avrdude-autoreset to become avrdude.
     $ ln -s /usr/bin/avrdude-autoreset /usr/bin/avrdude
 
 Modify the autoreset script to use the pin that you wired up to the reset pin.  See the line in
-autoreset where we do "pin = 4" and change the 4 to your gpio pin number.
+autoreset where we do "PIN = 4" and change the 4 to your GPIO pin number.
 
-Now when you run avrdude from anywhere (including via arduino's normal UI) it will flag dtr when
+Now when you run avrdude from anywhere (including via arduino's normal UI) it will flag DTR when
 it is about to upload hex data.
 
 To upload to the RFM12/69Pi (ATmega328 @ 8Mhz):
 
-    $ avrdude -v  -c arduino -p ATMEGA328P -P /dev/ttyAMA0 -b 38400 -U flash:w:sketch_name.hex
+    $ avrdude -v -c arduino -p ATMEGA328P -P /dev/ttyAMA0 -b 38400 -U flash:w:sketch_name.hex
 
 To upload to the emonPi (ATmega328 @ 16Mhz): 
 
     $ avrdude -v -c arduino -p ATMEGA328P -P /dev/ttyAMA0 -b 115200 -U flash:w:sketch_name.hex
 
-http://www.deanmao.com/2012/08/12/fixing-the-dtr-pin/
-
 Make sure Python is installed:
 
     $ sudo apt-get update
-    $ sudo apt-get install python-dev
-    $ sudo apt-get install python-rpi.gpio
+    $ sudo apt-get install python3-dev
+    $ sudo apt-get install python3-rpi.gpio

--- a/autoreset
+++ b/autoreset
@@ -1,9 +1,7 @@
 #!/usr/bin/python3
 
 import sys
-import os
 import time
-import fcntl
 import RPi.GPIO as GPIO
 
 DTR = 'TIOCM_DTR'
@@ -20,25 +18,15 @@ def reset():
 def process():
     start = time.time()
     while True:
-        try:
-            duration = time.time() - start
-            text = sys.stdin.readline().strip()
-            if DTR in text:
-                reset()
-                return  # FIXME this will close stdin at exit and caused Broken Pipe errors. We should continue to act as a filter.
-            elif duration > MAX_TIME:
-                return
-        except Exception as e:
-            if hasattr(e, 'errno'):  # FIXME ignoring EAGAIN is a side-effect of using non-blocking IO, but readline hides this from us and returns '' if there is no data. Don't use non-blocking IO.
-                if e.errno != 11: # Ignore resource unavailable
-                    raise
-            else:
-                raise
-def main():
-    fd = sys.stdin.fileno()
-    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+        duration = time.time() - start
+        text = sys.stdin.readline()
+        if DTR in text:
+            reset()
+            return  # FIXME this will close stdin at exit and caused Broken Pipe errors. We should continue to act as a filter.
+        elif duration > MAX_TIME:
+            return
 
+def main():
     GPIO.setwarnings(False)  # FIXME why disable warnings? This seems unwise!
     GPIO.setmode(GPIO.BOARD)
     process()

--- a/autoreset
+++ b/autoreset
@@ -2,6 +2,7 @@
 
 import sys
 import time
+import signal
 import RPi.GPIO as GPIO
 
 DTR = 'TIOCM_DTR'
@@ -16,17 +17,14 @@ def reset():
     GPIO.output(PIN, GPIO.LOW)
 
 def process():
-    start = time.time()
     while True:
-        duration = time.time() - start
         text = sys.stdin.readline()
         if DTR in text:
             reset()
             return  # FIXME this will close stdin at exit and caused Broken Pipe errors. We should continue to act as a filter.
-        elif duration > MAX_TIME:
-            return
 
 def main():
+    signal.alarm(MAX_TIME)
     GPIO.setwarnings(False)  # FIXME why disable warnings? This seems unwise!
     GPIO.setmode(GPIO.BOARD)
     process()

--- a/autoreset
+++ b/autoreset
@@ -1,45 +1,49 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
+import sys
+import os
+import time
+import fcntl
 import RPi.GPIO as GPIO
-import sys, os, re, time, fcntl
-import errno
 
-fd = sys.stdin.fileno()
-fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
-
-GPIO.setwarnings(False)
-GPIO.setmode(GPIO.BOARD)
-dtr = re.compile('.+TIOCM_DTR.+')
-start = time.time()
-pin = 7
+DTR = 'TIOCM_DTR'
+PIN = 7
 
 def reset():
-  GPIO.setup(pin, GPIO.OUT)
-  GPIO.output(pin, GPIO.HIGH)
-  time.sleep(0.32)
-  GPIO.output(pin, GPIO.LOW)
+    GPIO.setup(PIN, GPIO.OUT)
+    GPIO.output(PIN, GPIO.HIGH)
+    time.sleep(0.32)  # FIXME arbitrary constant. where did it come from? give it a name.
+    GPIO.output(PIN, GPIO.LOW)
 
 def process():
-  while True:
-    try: 
-      duration = time.time() - start
-      input = sys.stdin.readline().strip()
-      if input is None: # == "":
-        input = sys.stdin.readline().strip()
-      if dtr.match(input):
-        reset()
-        return
-      elif duration > 5000:
-        return
-    except Exception as e:
-      if hasattr(e, 'errno'):
-	if e.errno != 11: # Ignore resource unavailable
-         raise
-      else:
-        raise
+    start = time.time()
+    while True:
+        try:
+            duration = time.time() - start
+            text = sys.stdin.readline().strip()
+            if text is None: # == "":  # FIXME strip will never return None
+                text = sys.stdin.readline().strip()
+            if DTR in text:
+                reset()
+                return  # FIXME this will close stdin at exit and caused Broken Pipe errors. We should continue to act as a filter.
+            elif duration > 5000: # FIXME arbitrary constant. 5000 seconds (1h23m) is a long time. where did it come from?
+                return
+        except Exception as e:
+            if hasattr(e, 'errno'):  # FIXME ignoring EAGAIN is a side-effect of using non-blocking IO, but readline hides this from us and returns '' if there is no data. Don't use non-blocking IO.
+                if e.errno != 11: # Ignore resource unavailable
+                    raise
+            else:
+                raise
+def main():
+    fd = sys.stdin.fileno()
+    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
-process()
-print "avrdude-original: Using autoreset DTR on GPIO Pin " +str(pin)
-GPIO.cleanup()
-exit
+    GPIO.setwarnings(False)  # FIXME why disable warnings? This seems unwise!
+    GPIO.setmode(GPIO.BOARD)
+    process()
+    print("avrdude-original: Using autoreset DTR on GPIO Pin", PIN)
+    GPIO.cleanup()
+
+if __name__ == '__main__':
+    main()

--- a/autoreset
+++ b/autoreset
@@ -8,11 +8,12 @@ import RPi.GPIO as GPIO
 
 DTR = 'TIOCM_DTR'
 PIN = 7
+PULSE_TIME = 0.32
 
 def reset():
     GPIO.setup(PIN, GPIO.OUT)
     GPIO.output(PIN, GPIO.HIGH)
-    time.sleep(0.32)  # FIXME arbitrary constant. where did it come from? give it a name.
+    time.sleep(PULSE_TIME)
     GPIO.output(PIN, GPIO.LOW)
 
 def process():

--- a/autoreset
+++ b/autoreset
@@ -9,6 +9,7 @@ import RPi.GPIO as GPIO
 DTR = 'TIOCM_DTR'
 PIN = 7
 PULSE_TIME = 0.32
+MAX_TIME = 5000
 
 def reset():
     GPIO.setup(PIN, GPIO.OUT)
@@ -25,7 +26,7 @@ def process():
             if DTR in text:
                 reset()
                 return  # FIXME this will close stdin at exit and caused Broken Pipe errors. We should continue to act as a filter.
-            elif duration > 5000: # FIXME arbitrary constant. 5000 seconds (1h23m) is a long time. where did it come from?
+            elif duration > MAX_TIME:
                 return
         except Exception as e:
             if hasattr(e, 'errno'):  # FIXME ignoring EAGAIN is a side-effect of using non-blocking IO, but readline hides this from us and returns '' if there is no data. Don't use non-blocking IO.

--- a/autoreset
+++ b/autoreset
@@ -19,16 +19,17 @@ def reset():
 def process():
     while True:
         text = sys.stdin.readline()
+        if not text:
+            return
         if DTR in text:
+            print("avrdude-original: Using autoreset DTR on GPIO Pin", PIN)
             reset()
-            return  # FIXME this will close stdin at exit and caused Broken Pipe errors. We should continue to act as a filter.
 
 def main():
     signal.alarm(MAX_TIME)
     GPIO.setwarnings(False)  # FIXME why disable warnings? This seems unwise!
     GPIO.setmode(GPIO.BOARD)
     process()
-    print("avrdude-original: Using autoreset DTR on GPIO Pin", PIN)
     GPIO.cleanup()
 
 if __name__ == '__main__':

--- a/autoreset
+++ b/autoreset
@@ -22,8 +22,6 @@ def process():
         try:
             duration = time.time() - start
             text = sys.stdin.readline().strip()
-            if text is None: # == "":  # FIXME strip will never return None
-                text = sys.stdin.readline().strip()
             if DTR in text:
                 reset()
                 return  # FIXME this will close stdin at exit and caused Broken Pipe errors. We should continue to act as a filter.

--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-sudo apt-get install -y avrdude python-dev python-rpi.gpio minicom
+sudo apt-get install -y avrdude python3-dev python3-rpi.gpio minicom
 
 echo "install avrdude autoreset"
 
@@ -13,7 +13,3 @@ if [ ! -f /usr/bin/avrdude-original ]; then
 fi
 
 sudo ln -sf $DIR/avrdude-autoreset /usr/bin/avrdude
-
-
-
-


### PR DESCRIPTION
This is a port and a rewrite. It's much simpler than the tentacles this code has grown over the years leads one to believe! I hope this simplification is still sufficient. Specifically, I removed all the nonblocking complexity.

One change that this introduces is that the code will now toggle the reset any time the DTR ioctl is called, not just the first time. I don't know if this is a bug fix or an incompatible behaviour change. Testing needed.

The code still has a 5000s timeout, but it uses an alarm signal now instead of checking thousands of times a second. I don't know why this timeout is needed, but I left it in anyway.

Also the code disables the GPIO warnings. This seems like a bad idea to me that is hiding some bug, but I also left that in.