### PR TITLE
Fix issue when script not on path

### DIFF
--- a/avrdude-autoreset
+++ b/avrdude-autoreset
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-sudo strace -o "|autoreset" -eioctl /usr/bin/avrdude-original $@
+BASEDIR=$(dirname "$0")
+sudo strace -o "|${BASEDIR}/autoreset" -eioctl ${BASEDIR}/avrdude-original $@


### PR DESCRIPTION
Fix issue when avrdude is called from the users local .arduino15/packages/arduino/tools/.../bin and this is not on path